### PR TITLE
std::string concatenation has been removed to optimize loops

### DIFF
--- a/blobstamper/stamp_text.cpp
+++ b/blobstamper/stamp_text.cpp
@@ -15,56 +15,39 @@
  * limitations under the License.
  *
  ******************************************************************************/
+#include <sstream>
 
 #include"stamp_text.h"
+#include "utils.h"
 
 std::string
 StampTextPulp::ExtractStr(std::shared_ptr<Blob> blob)
 {
     std::vector<char> data = blob->Chop(minSize(), maxSize())->AsByteVector();
+  if (data.empty())
+  {
+    return {};
+  }
+  std::ostringstream ss;
 
-    std::vector<char>::iterator the_iterator;
+  for (auto sym : data)
+  {
+    if (sym == '\0') { sym = ' '; }
+    ss << sym;
+  }
 
-    the_iterator = data.begin();
-    std:: string res;
-    while (the_iterator != data.end())
-    {
-      if (*the_iterator == '\0') { *the_iterator = ' '; }
-      res.push_back(*the_iterator++);
-    }
-
-    return res;
+  return ss.str();
 }
 
 std::string StampTextPulpWords::ExtractStr(std::shared_ptr<Blob> blob)
 {
   std::vector<std::string> data = ExtractStrVector(blob);
-  std::string res = "";
-
-  for(std::string s : data)
-  {
-    if (!res.empty())
-    {
-      res+=" ";
-    }
-    res+= s;
-  }
-  return res;
+  return Utils::join(data, " ");
 }
 
 std::string StampTextDictWords::ExtractStr(std::shared_ptr<Blob> blob)
 {
   std::vector<std::string> data = ExtractStrVector(blob);
-  std::string res = "";
-
-  for(std::string s : data)
-  {
-    if (!res.empty())
-    {
-      res+=" ";
-    }
-    res+= s;
-  }
-  return res;
+  return Utils::join(data, " ");
 }
 

--- a/blobstamper/utils.h
+++ b/blobstamper/utils.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright 2021 Nikolay Shaplov (Postgres Professional)
+ * Copyright 2021-2024 Nikolay Shaplov (Postgres Professional)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,18 +15,25 @@
  * limitations under the License.
  *
  ******************************************************************************/
+#include <sstream>
 
-#include "stamp_enumerator.h"
-
-#include"galley.h"
-#include"stamp.h"
-#include"blob.h"
-#include "utils.h" 
-
-std::string StampStrEnumerator::ExtractStr(std::shared_ptr<Blob> blob)
+namespace Utils
 {
-  std::vector<std::string> data = ExtractStrVector(blob);
-  auto res = Utils::join(data, separator);
-  res = left_bracket + res + right_bracket;
-  return res;
+template <typename T>
+    std::string join(const T &container, const std::string &delimiter)
+    {
+        std::ostringstream oss;
+        if (container.empty())
+        {
+            return {};
+        }        
+        for (auto it = container.cbegin(); it != container.cend(); ++it)
+        {
+            oss << *it << delimiter;
+        }
+
+        auto res = oss.str();
+        res.resize(res.size() - delimiter.size());
+        return res;
+    }
 }


### PR DESCRIPTION
The join() template function is implemented
to convert stl containers to a string.